### PR TITLE
Upgrade to Scala 3.0.0-M2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.12, 2.13.3, 3.0.0-M1]
+        scala: [2.12.12, 2.13.3, 3.0.0-M2, 3.0.0-M3]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"
 
-ThisBuild / crossScalaVersions := Seq("2.12.12", "2.13.3", "3.0.0-M2")
+ThisBuild / crossScalaVersions := Seq("2.12.12", "2.13.3", "3.0.0-M2", "3.0.0-M3")
 ThisBuild / scalaVersion := crossScalaVersions.value.filter(_.startsWith("2.")).last
 ThisBuild / baseVersion := "2.0"
 ThisBuild / publishGithubUser := "rossabaker"
@@ -9,7 +9,7 @@ ThisBuild / publishFullName := "Ross A. Baker"
 ThisBuild / githubWorkflowPublishTargetBranches := Seq.empty
 
 val JawnVersion   = "1.0.3"
-val Fs2Version    = "3.0.0-M6"
+val Fs2Version    = "3.0.0-M7"
 val Specs2Version = "4.10.5"
 
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"
 
-ThisBuild / crossScalaVersions := Seq("2.12.12", "2.13.3", "3.0.0-M1")
+ThisBuild / crossScalaVersions := Seq("2.12.12", "2.13.3", "3.0.0-M2")
 ThisBuild / scalaVersion := crossScalaVersions.value.filter(_.startsWith("2.")).last
 ThisBuild / baseVersion := "2.0"
 ThisBuild / publishGithubUser := "rossabaker"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
 addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.9.5")
 addSbtPlugin("com.codecommit" % "sbt-spiewak" % "0.17.0")
 addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.17.0")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/src/main/scala/org/typelevel/jawn/fs2/package.scala
+++ b/src/main/scala/org/typelevel/jawn/fs2/package.scala
@@ -85,7 +85,7 @@ package object fs2 { self =>
         F: ApplicativeError[F, Throwable],
         A: Absorbable[O],
         facade: Facade[J]): Stream[F, J] =
-      stream.through(self.parseJson(mode))
+      stream.through(fs2.parseJson(mode))
 
     /** Parses the source to a single JSON optional JSON value.
       *
@@ -108,7 +108,7 @@ package object fs2 { self =>
         F: ApplicativeError[F, Throwable],
         A: Absorbable[O],
         facade: Facade[J]): Stream[F, J] =
-      stream.through(self.parseJsonStream)
+      stream.through(fs2.parseJsonStream)
 
     /** Emits elements of an outer JSON array as they are parsed.
       *
@@ -119,6 +119,6 @@ package object fs2 { self =>
         F: ApplicativeError[F, Throwable],
         A: Absorbable[O],
         facade: Facade[J]): Stream[F, J] =
-      stream.through(self.unwrapJsonArray)
+      stream.through(fs2.unwrapJsonArray)
   }
 }


### PR DESCRIPTION
Necessary because jawn-1.0.3 isn't released for 3.0.0-M1, and there's no fs2 for 3.0.0-M3 yet.

Curiously, the self type on the object stopped working.