### PR TITLE
Fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jawn-fs2 [![Build Status](https://travis-ci.org/typelevel/jawn-fs2.svg?branch=master)](https://travis-ci.org/typelevel/jawn-fs2) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.http4s/jawn-fs2_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.http4s/jawn-fs2_2.12)
+# jawn-fs2 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.typelevel/jawn-fs2_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.typelevel/jawn-fs2_2.13)
 
 Asynchronously parse [fs2](https://github.com/functional-streams-for-scala/fs2) streams
 to JSON values with [jawn](https://github.com/non/jawn).


### PR DESCRIPTION
* Last release badge still pointed to `org.http4s`
* CI badge pointed to Travis CI.  If anyone's got a GitHub Actions one handy, happy to add it.