### PR TITLE
Gitignore .bsp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ atlassian-ide-plugin.xml
 .tags
 .tags_sorted_by_file
 .ensime_lucene
+.bsp


### PR DESCRIPTION
The next release is going to fail for being a SNAPSHOT if we don't ignore this file after #209.