### PR TITLE
Use toByteBuffer in ByteChunkAbsorbable to avoid allocating an array

### DIFF
--- a/core/src/main/scala/org/typelevel/jawn/fs2/Absorbable.scala
+++ b/core/src/main/scala/org/typelevel/jawn/fs2/Absorbable.scala
@@ -50,6 +50,6 @@ object Absorbable {
     new Absorbable[C] {
       override def absorb[J](parser: AsyncParser[J], chunk: C)(implicit
           rawFacade: Facade[J]): Either[ParseException, collection.Seq[J]] =
-        parser.absorb(chunk.toArray)
+        parser.absorb(chunk.toByteBuffer)
     }
 }


### PR DESCRIPTION
The latest version of fs2 has an efficient `toByteBuffer` method, which maybe be executed in O(1) time and space if the subtype of `Chunk` happens to be the correct one. If it's the wrong subtype, it fallbacks to the same `toArray` method the current `jawn-fs2` code uses. 

This should result in reduced CPU usage and lower memory usage as we're no longer allocating a whole new byte array and not copying over the data.

Note jawn AsyncParser already has a `absorb(b: ByteBuffer)` so nothing needs to change on that end.

https://github.com/typelevel/fs2/blob/1f5f2310456b18fb1e5f23e31b24ff387797d3eb/core/shared/src/main/scala/fs2/Chunk.scala#L305-L319

Note this should synergise with https://github.com/typelevel/fs2/pull/2990.